### PR TITLE
Add Pocket-powered xDAI load-balanced RPC endpoint

### DIFF
--- a/connecting-to-xdai/changing-your-rpc-endpoint.md
+++ b/connecting-to-xdai/changing-your-rpc-endpoint.md
@@ -6,3 +6,8 @@ You can change the RPC endpoint that the Dark Forest client connects to in the s
 
 In addition to the xDAI-provided [https://rpc-df.xdaichain.com](https://rpc-df.xdaichain.com) endpoint, xDAI also provides a number of other [public endpoints](https://www.xdaichain.com/for-developers/developer-resources).
 
+Last but not least, Pocket Network has gifted the Dark Forest community an xDAI RPC load-balanced endpoint capable of handling up to 10,000,000 requests per day by staking upwards of 250k POKT on their behalf.
+
+[https://poa-xdai.gateway.pokt.network/v1/lb/60b13899d3279c22da2a444d](https://poa-xdai.gateway.pokt.network/v1/lb/60b13899d3279c22da2a444d)
+
+Overtime, this will be scaled up to handle more traffic!


### PR DESCRIPTION
This public endpoint can support up to 10M requests per day (or 416k requests per hour).

It's hot-swappable with any other RPC endpoint url offered by centralized node infrastructure providers.

However, instead of getting served by one node, you'll be served by multiple nodes every hour coordinated by a decentralized protocol Pocket Network.

For example, anytime DF connects to xDAI using this endpoint, it gets automatically paired in a session with 5 random Pocket nodes in the network which point to xDAI nodes ran by node runners. Every hour, it gets tumbled into a new session with 5 other random nodes in the network. 

Even if one node went down, it would still be served by the rest of the nodes in that session.

These node runners are incentivized by earning POKT to ensure constant uptime and reliable service. 

This is a load-balanced endpoint, too. We've mapped 10 application authentication tokens (AATs) to this endpoint, so the 10M requests would be distributed equally across 10 parallel sessions each with 5 nodes. 