### PR TITLE
feat(gha-deploy): add developer.zkga.me cname

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
         run: |
           npm install
           npm run build
+          echo 'developer.zkga.me' > public/CNAME
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5


### PR DESCRIPTION
@gubsheep You should probably add @ichub as an owner here, I cant

* A previous commit moved to honkit because you can do anything locally with gitbook (though gitbook still works)
* Another previous commit publishes this repo to github pages on push to master 
https://darkforest-eth.github.io/developer-guides/

My last request is if we can get the developer.zkga.me cname setup?

Step 5 from here
https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain